### PR TITLE
new: config: move mapping of users to privilege levels into Configuratin

### DIFF
--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -211,24 +211,7 @@ if ($errors != '') {
   exit;
 }
 
-switch ($EPPN) {
-  case 'bjorn@sunet.se' :
-  case 'pax@sunet.se' :
-  case 'jocar@sunet.se' :
-  case 'mifr@sunet.se' :
-    $userLevel = 20;
-    break;
-  case 'frkand02@umu.se' :
-  case 'paulscot@kau.se' :
-    $userLevel = 10;
-    break;
-  case 'johpe12@liu.se' :
-  case 'toylon98@umu.se' :
-    $userLevel = 5;
-    break;
-  default :
-    $userLevel = 1;
-}
+$userLevel = $config->getUserLevels()[$EPPN] ?? 1;
 $displayName = '<div> Logged in as : <br> ' . $fullName . ' (' . $EPPN .')</div>';
 $html->setDisplayName($displayName);
 

--- a/web/html/admin/mds.php
+++ b/web/html/admin/mds.php
@@ -33,24 +33,8 @@ if (isset($_SERVER['displayName'])) {
   $fullName = '';
 }
 
-switch ($EPPN) {
-  case 'bjorn@sunet.se' :
-  case 'pax@sunet.se' :
-  case 'jocar@sunet.se' :
-  case 'mifr@sunet.se' :
-    $userLevel = 20;
-    break;
-  case 'frkand02@umu.se' :
-  case 'paulscot@kau.se' :
-    $userLevel = 10;
-    break;
-  case 'johpe12@liu.se' :
-  case 'toylon98@umu.se' :
-    $userLevel = 5;
-    break;
-  default :
-    exit;
-}
+$userLevel = $config->getUserLevels()[$EPPN] ?? 1;
+if ($userLevel < 5) { exit; };
 $displayName = '<div> Logged in as : <br> ' . $fullName . ' (' . $EPPN .')</div>';
 $html->setDisplayName($displayName);
 $collapseIcons = array();

--- a/web/html/admin/status.php
+++ b/web/html/admin/status.php
@@ -30,16 +30,8 @@ if (isset($_SERVER['displayName'])) {
   $fullName = '';
 }
 
-switch ($EPPN) {
-  case 'bjorn@sunet.se' :
-  case 'pax@sunet.se' :
-  case 'jocar@sunet.se' :
-  case 'mifr@sunet.se' :
-    $userLevel = 20;
-    break;
-  default :
-    exit;
-}
+$userLevel = $config->getUserLevels()[$EPPN] ?? 1;
+if ($userLevel < 20) { exit; };
 $displayName = '<div> Logged in as : <br> ' . $fullName . ' (' . $EPPN .')</div>';
 $html->setDisplayName($displayName);
 

--- a/web/html/config.template.php
+++ b/web/html/config.template.php
@@ -45,3 +45,10 @@ $smtp = array(
 
 $mode = 'Lab';
 $baseURL = 'https://metadata.host.se/';
+
+$userLevels = array(
+  'adminuser1@federation.org' => 20,
+  'adminuser2@federation.org' => 20,
+  'user1@inst1.org' => 10,
+  'user1@inst2.org' => 5,
+);

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -11,11 +11,12 @@ class Configuration {
   private $baseURL = '';
   private $entitySelectionProfiles = array();
   private $db;
+  private $userLevels = array(); // indexed by username, maps to user privilege level
 
   public function __construct($startDB = true) {
     include __DIR__ . '/../config.php'; # NOSONAR
 
-    $reqParams = array('db', 'smtp', 'mode', 'baseURL');
+    $reqParams = array('db', 'smtp', 'mode', 'baseURL', 'userLevels');
     $reqParamsDB = array('servername', 'username', 'password',
       'name');
     $reqParamsSmtp = array('host', 'from', 'replyTo', 'replyName', 'sendOut');
@@ -92,6 +93,9 @@ class Configuration {
     if ($startDB) {
       $this->checkInstanceExitInDB($this->scope);
     }*/
+
+    # Users
+    $this->userLevels = $userLevels;
   }
 
   private function checkDBVersion() {
@@ -187,6 +191,10 @@ class Configuration {
 
   public function getDb() {
     return $this->db;
+  }
+
+  public function getUserLevels() {
+    return $this->userLevels;
   }
 
   public function getMode() {


### PR DESCRIPTION
Add a new setting userLevels as an array mapping user identifiers (EPPN) to userLevel values.

Replace hard-coded mapping of user to userLevels with a lookup through this array, using 1 as default.

In cases where no mapping triggers an exit (mds, status), exit if the value is below minimum threshold.