### PR TITLE
Reuse parsing protocolSupportEnumeration for AttributeAuthorityDescriptor

### DIFF
--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -1170,6 +1170,7 @@ function validateEntity($entitiesId) {
     CLASS_VALIDATOR.$config->getFederation()['extend'] :
     CLASS_VALIDATOR;
   $parser = new $xmlParser($entitiesId);
+  $parser->clearResult();
   $parser->clearWarning();
   $parser->clearError();
   $parser->parseXML();

--- a/web/html/src/ParseXML.php
+++ b/web/html/src/ParseXML.php
@@ -661,8 +661,7 @@ class ParseXML extends Common {
    */
   protected function parseAttributeAuthorityDescriptor($data) {
     $keyOrder = 0;
-    $saml2found = false;
-    $saml1found = false;
+    list($saml2found, $saml1found, $shibboleth10found) = $this->parseProtocolSupportEnumeration($data);
     # https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf 2.4.1 + 2.4.2 + 2.4.7
     $child = $data->firstChild;
     while ($child) {

--- a/web/html/src/ParseXML.php
+++ b/web/html/src/ParseXML.php
@@ -111,7 +111,7 @@ class ParseXML extends Common {
           break;
         #case self::SAML_MD_ADDITIONALMETADATALOCATION :
         default :
-          $this->result .= $child->nodeType == 8 ? '' : sprintf("%s missing in validator.\n", $child->nodeName);
+          $this->result .= $child->nodeType == 8 ? '' : sprintf("Unknown element %s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -173,7 +173,7 @@ class ParseXML extends Common {
           $this->error .= "Scope found in Extensions should be below IDPSSODescriptor/Extensions.\n";
           break;
         default :
-          $this->result .= sprintf("Extensions->%s missing in validator.\n", $child->nodeName);
+          $this->result .= sprintf("Unknown element Extensions->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -193,7 +193,7 @@ class ParseXML extends Common {
         $this->parseExtensionsEntityAttributesAttribute($child);
       } else {
         $this->result .= $child->nodeType == 8 ? '' :
-        sprintf("Extensions->EntityAttributes->%s missing in validator.\n", $child->nodeName);
+        sprintf("Unknown element Extensions->EntityAttributes->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -343,7 +343,7 @@ class ParseXML extends Common {
           break;
         default :
         $this->result .= $child->nodeType == 8 ? '' :
-          sprintf("IDPSSODescriptor->%s missing in validator.\n", $child->nodeName);
+          sprintf("Unknown element IDPSSODescriptor->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -409,7 +409,7 @@ class ParseXML extends Common {
         case self::SAML_PSC_REQUESTEDPRINCIPALSELECTION :
           break;
         default :
-          $this->result .= sprintf("IDPSSODescriptor->Extensions->%s missing in validator.\n", $child->nodeName);
+          $this->result .= sprintf("Unknown element IDPSSODescriptor->Extensions->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -499,7 +499,7 @@ class ParseXML extends Common {
           break;
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("SPSSODescriptor->%s missing in validator.\n", $child->nodeName);
+            sprintf("Unknown element SPSSODescriptor->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -535,7 +535,7 @@ class ParseXML extends Common {
           break;
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("SPSSODescriptor->Extensions->%s missing in validator.\n", $child->nodeName);
+            sprintf("Unknown element SPSSODescriptor->Extensions->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -651,7 +651,7 @@ class ParseXML extends Common {
           break;
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("SPSSODescriptor->AttributeConsumingService->%s missing in validator.\n", $child->nodeName);
+            sprintf("Unknown element SPSSODescriptor->AttributeConsumingService->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -708,7 +708,7 @@ class ParseXML extends Common {
 
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("AttributeAuthorityDescriptor->%s missing in validator.\n", $child->nodeName);
+            sprintf("Unknown element AttributeAuthorityDescriptor->%s found in metadata.\n", $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -744,7 +744,7 @@ class ParseXML extends Common {
           $element = substr($child->nodeName, 3); #NOSONAR Used in Bind above
           break;
         default :
-          $this->result .= sprintf("Organization->%s missing in validator.\n", $child->nodeName);
+          $this->result .= sprintf("Unknown element Organization->%s found in metadata.\n", $child->nodeName);
       }
       $organizationHandler->bindValue(self::BIND_VALUE, trim($child->textContent));
       $organizationHandler->execute();
@@ -826,7 +826,7 @@ class ParseXML extends Common {
           $telephoneNumber = $value;
           break;
         default :
-          $this->result .= sprintf("ContactPerson->%s missing in validator.\n", $child->nodeName);
+          $this->result .= sprintf("Unknown element ContactPerson->%s found in metadata.\n", $child->nodeName);
       }
       if ($value == '') {
         $this->error .= sprintf ("Error in uploaded XML. Element %s in contact type=%s is empty!\n",
@@ -962,7 +962,7 @@ class ParseXML extends Common {
           $this->result .= sprintf("Extra space found in protocolSupportEnumeration for $name. Please remove.\n");
           break;
         default :
-          $this->result .= sprintf("Unknown protocol %s found in validator for $name.\n", $protocol);
+          $this->result .= sprintf("Unknown protocol %s found in protocolSupportEnumeration for $name.\n", $protocol);
       }
     }
 
@@ -1003,7 +1003,7 @@ class ParseXML extends Common {
           break;
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("%sDescriptor->KeyDescriptor->%s missing in validator.\n", $type, $child->nodeName);
+            sprintf("Unknown element %sDescriptor->KeyDescriptor->%s found in metadata.\n", $type, $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -1043,7 +1043,7 @@ class ParseXML extends Common {
           break;
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("%sDescriptor->KeyDescriptor->KeyInfo->%s missing in validator.\n", $type, $child->nodeName);
+            sprintf("Unknown element %sDescriptor->KeyDescriptor->KeyInfo->%s found in metadata.\n", $type, $child->nodeName);
       }
       $child = $child->nextSibling;
     }
@@ -1172,7 +1172,7 @@ class ParseXML extends Common {
         #case'ds:X509CRL' :
         default :
           $this->result .= $child->nodeType == 8 ? '' :
-            sprintf("%sDescriptor->KeyDescriptor->KeyInfo->X509Data->%s missing in validator.\n",
+            sprintf("Unknown element %sDescriptor->KeyDescriptor->KeyInfo->X509Data->%s found in metadata.\n",
               $type, $child->nodeName);
       }
       $child = $child->nextSibling;

--- a/web/html/src/ParseXML.php
+++ b/web/html/src/ParseXML.php
@@ -945,7 +945,7 @@ class ParseXML extends Common {
           $this->result .= sprintf("Extra space found in protocolSupportEnumeration for $name. Please remove.\n");
           break;
         default :
-          $this->result .= sprintf("Protocol %s missing in validator for $name.\n", $protocol);
+          $this->result .= sprintf("Unknown protocol %s found in validator for $name.\n", $protocol);
       }
     }
     return array($saml2found, $saml1found, $shibboleth10found);

--- a/web/html/src/ParseXML.php
+++ b/web/html/src/ParseXML.php
@@ -452,7 +452,7 @@ class ParseXML extends Common {
     $keyOrder = 0;
     list($saml2found, $saml1found, $shibboleth10found) = $this->parseProtocolSupportEnumeration($data);
     if ($shibboleth10found) {
-      $this->errorNB .= sprintf("Protocol urn:mace:shibboleth:1.0 should only be used on IdP:s protocolSupportEnumeration, found in SPSSODescriptor.\n", $protocol);
+      $this->errorNB .= sprintf("Protocol urn:mace:shibboleth:1.0 should only be used on IdP:s protocolSupportEnumeration, found in SPSSODescriptor.\n");
     }
     # https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf 2.4.1 + 2.4.2 + 2.4.4
     $child = $data->firstChild;

--- a/web/html/src/ParseXMLSWAMID.php
+++ b/web/html/src/ParseXMLSWAMID.php
@@ -22,11 +22,9 @@ class ParseXMLSWAMID extends ParseXML {
   protected function parseIDPSSODescriptor($data) {
     parent::parseIDPSSODescriptor($data);
 
-    list($saml2found, $saml1found, $shibboleth10found) = $this->parseProtocolSupportEnumeration($data);
-
-    if (! $saml2found) {
+    if (! $this->samlProtocolSupportFound[self::SAML_MD_IDPSSODESCRIPTOR]['saml2']) {
       $this->error .= "IDPSSODescriptor is missing support for SAML2.\n";
-    } elseif ($saml1found) {
+    } elseif ($this->samlProtocolSupportFound[self::SAML_MD_IDPSSODESCRIPTOR]['saml1']) {
       $this->warning .= "IDPSSODescriptor claims support for SAML1. SWAMID is a SAML2 federation\n";
     }
   }
@@ -47,11 +45,9 @@ class ParseXMLSWAMID extends ParseXML {
   protected function parseSPSSODescriptor($data) {
     parent::parseSPSSODescriptor($data);
 
-    list($saml2found, $saml1found, $shibboleth10found) = $this->parseProtocolSupportEnumeration($data);
-
-    if (! $saml2found) {
+    if (! $this->samlProtocolSupportFound[self::SAML_MD_SPSSODESCRIPTOR]['saml2']) {
       $this->error .= "SPSSODescriptor is missing support for SAML2.\n";
-    } elseif ($saml1found) {
+    } elseif ($this->samlProtocolSupportFound[self::SAML_MD_SPSSODESCRIPTOR]['saml1']) {
       $this->errorNB .= "SPSSODescriptor claims support for SAML1. SWAMID is a SAML2 federation\n";
     }
     // 6.1.16

--- a/web/html/src/ParseXMLSWAMID.php
+++ b/web/html/src/ParseXMLSWAMID.php
@@ -22,9 +22,11 @@ class ParseXMLSWAMID extends ParseXML {
   protected function parseIDPSSODescriptor($data) {
     parent::parseIDPSSODescriptor($data);
 
-    if (! $this->saml2found) {
+    list($saml2found, $saml1found, $shibboleth10found) = $this->parseProtocolSupportEnumeration($data);
+
+    if (! $saml2found) {
       $this->error .= "IDPSSODescriptor is missing support for SAML2.\n";
-    } elseif ($this->saml1found) {
+    } elseif ($saml1found) {
       $this->warning .= "IDPSSODescriptor claims support for SAML1. SWAMID is a SAML2 federation\n";
     }
   }
@@ -45,9 +47,11 @@ class ParseXMLSWAMID extends ParseXML {
   protected function parseSPSSODescriptor($data) {
     parent::parseSPSSODescriptor($data);
 
-    if (! $this->saml2found) {
+    list($saml2found, $saml1found, $shibboleth10found) = $this->parseProtocolSupportEnumeration($data);
+
+    if (! $saml2found) {
       $this->error .= "SPSSODescriptor is missing support for SAML2.\n";
-    } elseif ($this->saml1found) {
+    } elseif ($saml1found) {
       $this->errorNB .= "SPSSODescriptor claims support for SAML1. SWAMID is a SAML2 federation\n";
     }
     // 6.1.16


### PR DESCRIPTION
Hi @btmattsson ,

Many thanks for refactoring the validation code.

I have now rolled that out in my testbed and this PR fixes some wrinkles I bumped into.

Main one was that for an IdP with an `AttributeAuthorityDescriptor`, I was getting Error:
> saml-bindings-2.0-os: SAML2 Binding in md:AttributeService[Binding=urn:oasis:names:tc:SAML:2.0:bindings:SOAP], but SAML2 not supported in AttributeAuthorityDescriptor.
even though the metadata was correct.

I found that the `parseAttributeAuthorityDescriptor` function was disconnected from how `protocolSupportEnumeration` was parsed in `parseIDPSSODescriptorparseIDPSSODescriptor`.

I have refactored that code into a reusable function `parseProtocolSupportEnumeration` that's now used by all the three `parse*Descriptor` functions.

As the results from the parsing are specific to the role descriptor parsed, I removed the top-level attributes of the `ParseXML` class holding the results, and these are stored only in local variables in the `parse*Descriptor` methods.

Unfortunately, in the `ParseXMLSWAMID` sub-class, I had to repeat the call to `parseProtocolSupportEnumeration` - could not see a good way to pass the result between the generic and federation-specific parse methods.

Please let me know if happy with this approach.

Cheers,
Vlad
