### PR TITLE
More metadata-sp tweaks

### DIFF
--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -898,7 +898,7 @@ function showEntity($entitiesId, $showHeader = true)  {
     if ($entity['isAA'] ) { $display->showAA($entitiesId, $oldEntitiesId, $allowEdit, $allowEdit); }
     $display->showOrganization($entitiesId, $oldEntitiesId, $allowEdit);
     $display->showContacts($entitiesId, $oldEntitiesId, $allowEdit);
-    if ($entity['status'] == 1) { $display->showMdqUrl($entity['entityID'], $config->getMode()); }
+    if ($entity['status'] == 1 && $federation['mdqBaseURL']) { $display->showMdqUrl($entity['entityID'], $config->getMode()); }
     $display->showXML($entitiesId);
     if ($oldEntitiesId > 0 && $userLevel > 10) {
       $display->showDiff($entitiesId, $oldEntitiesId);

--- a/web/html/config.template.php
+++ b/web/html/config.template.php
@@ -115,6 +115,8 @@ $federation = array(
   'checkOrganization' => false,
   # URL to get release-check test results from - or empty string if not used
   'releaseCheckResultsURL' => 'https://release-check.swamid.se/metaDump.php',
+  # Base URL for MDQ - or empty string if not available
+  'mdqBaseURL' => 'https://mds.swamid.se/entities/',
   # Optional if you want to extend Validate and ParseXML with an extended version
   # See ValidateSWAMID and ParseXMLSWAMID for examples
   #'extend' => 'SWAMID',

--- a/web/html/config.template.php
+++ b/web/html/config.template.php
@@ -113,6 +113,8 @@ $federation = array(
   'swamid_assurance' => true,
   # If we should check/force a organization connected to each entity
   'checkOrganization' => false,
+  # URL to get release-check test results from - or empty string if not used
+  'releaseCheckResultsURL' => 'https://release-check.swamid.se/metaDump.php',
   # Optional if you want to extend Validate and ParseXML with an extended version
   # See ValidateSWAMID and ParseXMLSWAMID for examples
   #'extend' => 'SWAMID',

--- a/web/html/config.template.php
+++ b/web/html/config.template.php
@@ -79,6 +79,7 @@ $federation = array(
 
   'rulesName' => 'SWAMID SAML WebSSO Technology Profile',
   'rulesURL' => 'https://www.swamid.se/policy/technology/saml-websso',
+  'roloverDocURL' => 'https://wiki.sunet.se/display/SWAMID/Key+rollover',
 
   'rulesSectsBoth' => '4.1.1, 4.1.2, 4.2.1 and 4.2.2',
   'rulesSectsIdP' => '4.1.1 and 4.1.2',

--- a/web/html/index.php
+++ b/web/html/index.php
@@ -238,7 +238,7 @@ function showEntity($entity_id, $urn = false)  {
     if ($entity['isAA'] ) { $display->showAA($entities_id, $oldEntity_id); }
     $display->showOrganization($entities_id, $oldEntity_id);
     $display->showContacts($entities_id, $oldEntity_id);
-    if ($entity['status'] == 1) { $display->showMdqUrl($entity['entityID'], $config->getMode()); }
+    if ($entity['status'] == 1 && $federation['mdqBaseURL']) { $display->showMdqUrl($entity['entityID'], $config->getMode()); }
     $display->showXML($entities_id);
   } else {
     $html->showHeaders('NotFound');

--- a/web/html/src/Common.php
+++ b/web/html/src/Common.php
@@ -273,6 +273,7 @@ class Common {
    * @return void
    */
   private function checkCurlReturnCode($ch, $output, $type, &$updateArray, &$verboseInfo) {
+    global $config;
     switch ($http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE)) {
       case 200 :
         $verboseInfo .= 'OK : content-type = ' . curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
@@ -321,7 +322,7 @@ class Common {
         break;
       default :
         $verboseInfo .= $http_code;
-        $updateArray[self::BIND_RESULT] = "Contact operation@swamid.se. Got code $http_code from web-server. Cant handle :-(";
+        $updateArray[self::BIND_RESULT] = sprintf("Contact %s. Got code %d from web-server. Cant handle :-(", $config->getFederation()['teamMail'], $http_code);
         $updateArray[self::BIND_STATUS] = 2;
         $updateArray[self::BIND_COCOV1STATUS] = 1;
     }

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -84,7 +84,8 @@ class Configuration {
       'rulesName', 'rulesURL',
       'rulesSectsBoth', 'rulesSectsIdP', 'rulesSectsSP',
       'rulesInfoBoth', 'rulesInfoIdP', 'rulesInfoSP',
-      'swamid_assurance', 'checkOrganization');
+      'swamid_assurance', 'checkOrganization',
+      'releaseCheckResultsURL');
 
     foreach ($reqParams as $param) {
       if (! isset(${$param})) {

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -85,7 +85,7 @@ class Configuration {
       'rulesSectsBoth', 'rulesSectsIdP', 'rulesSectsSP',
       'rulesInfoBoth', 'rulesInfoIdP', 'rulesInfoSP',
       'swamid_assurance', 'checkOrganization',
-      'releaseCheckResultsURL');
+      'releaseCheckResultsURL', 'mdqBaseURL');
 
     foreach ($reqParams as $param) {
       if (! isset(${$param})) {

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -81,7 +81,7 @@ class Configuration {
       'aboutURL', 'contactURL', 'toolName', 'teamName',
       'teamMail', 'logoURL', 'logoWidth', 'logoHeight', 'languages',
       'metadata_main_path', 'metadata_registration_authority_exclude',
-      'rulesName', 'rulesURL',
+      'rulesName', 'rulesURL', 'roloverDocURL',
       'rulesSectsBoth', 'rulesSectsIdP', 'rulesSectsSP',
       'rulesInfoBoth', 'rulesInfoIdP', 'rulesInfoSP',
       'swamid_assurance', 'checkOrganization',

--- a/web/html/src/IMPS.php
+++ b/web/html/src/IMPS.php
@@ -399,7 +399,7 @@ class IMPS {
             <div class="col-2">Left</div>
             <div class="col"><input type="text" name="notMemberAfter" value="%s" size="10"></div>
           </div>
-          <input type="submit">
+          <input type="submit" name="action" value="Add/Update">
         </form>
         <a href="./?action=Members&tab=organizations&id=%d%s#org-%d"><button>Back</button></a>%s',
         htmlspecialchars($memberSince), htmlspecialchars($notMemberAfter),

--- a/web/html/src/Metadata.php
+++ b/web/html/src/Metadata.php
@@ -398,10 +398,10 @@ class Metadata extends Common {
     foreach (explode(' ', $feeds) as $feed ) {
       switch (strtolower($feed)) {
         case $federation['localFeed'] :
-          $publishIn += 2;
+          $publishIn = 2;
           break;
         case $federation['eduGAINFeed'] :
-          $publishIn += 4;
+          $publishIn = 6; // localFeed + eduGAIN
           break;
         default :
       }

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -514,8 +514,8 @@ class MetadataDisplay extends Common {
               $entitiesId, 'Create new organization based on this entity', "\n");
           }
           printf('          Please select your organization.<br>
-          If this is a organization not already existing in SWAMID, keep "New Organization" in the dropdown list and inform %s (%s) during publication.<br>%s',
-            $this->config->getFederation()['teamName'], $this->config->getFederation()['teamMail'], "\n");
+          If this is a organization not already existing in %s, keep "New Organization" in the dropdown list and inform %s (%s) during publication.<br>%s',
+            $this->config->getFederation()['displayName'], $this->config->getFederation()['teamName'], $this->config->getFederation()['teamMail'], "\n");
         }
         $this->showAddOrganizationIdForm($entitiesId, $entity['OrganizationInfo_id']);
       } else {

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -1697,8 +1697,9 @@ class MetadataDisplay extends Common {
    * @return void
    */
   public function showMdqUrl($entityID, $mode) {
-    $this->showCollapse('Signed XML in SWAMID', 'MDQ', false, 0, true, false, 0, 0);
-    $url = sprintf('https://mds.swamid.se/%sentities/%s', $mode == 'QA' ? 'qa/' : '', urlencode($entityID));
+    $federation = $this->config->getFederation();
+    $this->showCollapse('Signed XML in ' . $federation['displayName'], 'MDQ', false, 0, true, false, 0, 0);
+    $url = sprintf('%s%s', $federation['mdqBaseURL'], urlencode($entityID));
     printf ('        URL at MDQ : <a href="%s">%s</a><br><br>%s',
       $url, $url, "\n");
     $this->showCollapseEnd('MDQ', 0);

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -2630,11 +2630,11 @@ class MetadataDisplay extends Common {
     <p>
       Based on release-check test performed over the last 12 months and Entity-Category-Support registered in metadata.
       <br>
-      Out of %d IdPs in swamid:
+      Out of %d IdPs in %s:
     </p>
     <table class="table table-striped table-bordered">
       <tr><th>EC</th><th>OK + ECS</th><th>OK no ECS</th><th>Fail</th><th>Not tested</th></tr>%s',
-      $nrOfIdPs, "\n");
+      $nrOfIdPs, $this->config->getFederation()['displayName'], "\n");
     foreach ($ecs as $ec => $descr) {
       $markedECS = $ecsTested[$ec]['MarkedWithECS'];
       $ok = $ecsTested[$ec]['OK'] > $ecsTested[$ec]['MarkedWithECS']

--- a/web/scripts/importXML.bash
+++ b/web/scripts/importXML.bash
@@ -11,7 +11,7 @@ if [ -r $file ]; then
     feed="Testing swamid-2.0"
   fi
   if [ $SWAMIDDir = "swamid-edugain" ]; then
-    feed="Testing swamid-2.0 swamid-edugain"
+    feed="Testing swamid-edugain"
   fi
 
   php /var/www/scripts/importAndValidateXML.php $file "$feed"

--- a/web/scripts/sendMailReminders.php
+++ b/web/scripts/sendMailReminders.php
@@ -429,6 +429,7 @@ function checkOldIMPS() {
 
 function sendEntityConfirmation($id, $entityID, $displayName, $months) {
   global $config, $mailContacts;
+  $federation = $config->getFederation();
 
   setupMail();
 
@@ -450,32 +451,44 @@ function sendEntityConfirmation($id, $entityID, $displayName, $months) {
   $mailContacts->Body    = sprintf("<html>\n  <body>
     <p>Hi.</p>
     <p>The entity \"%s\" (%s) has not been validated/confirmed for %d months.
-    The SWAMID SAML WebSSO Technology Profile requires an annual confirmation that the entity is operational
+    The %s requires an annual confirmation that the entity is operational
     and fulfils the Technology Profile.</p>
-    <p>If the entity should no longer be used within SWAMID please remove it from the metadata registry.</p>
-    <p>If not annually confirmed the Operations team will start the process to remove the entity from the SWAMID metadata registry.</p>
+    <p>If the entity should no longer be used within %s please remove it from the metadata registry.</p>
+    <p>If not annually confirmed the %s team will start the process to remove the entity from the %s metadata registry.</p>
     <p>You have received this email because you are either the technical and/or administrative contact.</p>
     <p>You can confirm, update or remove your entity at
     <a href=\"%sadmin/?showEntity=%d\">%sadmin/?showEntity=%d</a> .</p>
-    <p>This is a message from the SWAMID SAML WebSSO metadata administration tool.<br>
+    <p>This is a message from the %s.<br>
     --<br>
-    On behalf of SWAMID Operations</p>
+    On behalf of %s</p>
   </body>\n</html>",
-  $displayName, $entityID, $months, $config->baseURL(), $id, $config->baseURL(), $id);
+  $displayName, $entityID, $months,
+  $federation['rulesName'],
+  $federation['displayName'],
+  $federation['teamName'], $federation['displayName'],
+  $config->baseURL(), $id, $config->baseURL(), $id,
+  $federation['toolName'],
+  $federation['teamName']);
   $mailContacts->AltBody = sprintf("Hi.\n\nThe entity \"%s\" (%s) has not been validated/confirmed for %d months.
-    The SWAMID SAML WebSSO Technology Profile requires an annual confirmation that the entity is operational and fulfils
+    The %s requires an annual confirmation that the entity is operational and fulfils
     the Technology Profile.
-    \nIf the entity should no longer be used within SWAMID please remove it from the metadata registry.
-    \nIf not annually confirmed the Operations team will start the process to remove the entity from the SWAMID metadata registry.
+    \nIf the entity should no longer be used within %s please remove it from the metadata registry.
+    \nIf not annually confirmed the %s team will start the process to remove the entity from the %s metadata registry.
     \nYou have received this email because you are either the technical and/or administrative contact.
     \nYou can confirm, update or remove your entity at %sadmin/?showEntity=%d .
-    \nThis is a message from the SWAMID SAML WebSSO metadata administration tool.
+    \nThis is a message from the %s.
     --
-    On behalf of SWAMID Operations",
-    $displayName, $entityID, $months, $config->baseURL(), $id);
+    On behalf of %s",
+    $displayName, $entityID, $months,
+    $federation['rulesName'],
+    $federation['displayName'],
+    $federation['teamName'], $federation['displayName'],
+    $config->baseURL(), $id,
+    $federation['toolName'],
+    $federation['teamName']);
 
   $shortEntityid = preg_replace('/^https?:\/\/([^:\/]*)\/.*/', '$1', $entityID);
-  $mailContacts->Subject  = 'Warning : SWAMID metadata for ' . $shortEntityid . ' needs to be validated';
+  $mailContacts->Subject  = 'Warning : ' . $federation['displayName'] . ' metadata for ' . $shortEntityid . ' needs to be validated';
 
   try {
     $mailContacts->send();
@@ -486,6 +499,7 @@ function sendEntityConfirmation($id, $entityID, $displayName, $months) {
 
 function sendCertReminder($id, $entityID, $displayName, $maxStatus) {
   global $config, $mailContacts;
+  $federation = $config->getFederation();
 
   setupMail();
 
@@ -505,29 +519,39 @@ function sendCertReminder($id, $entityID, $displayName, $maxStatus) {
   $mailContacts->isHTML(true);
   $mailContacts->Body    = sprintf("<html>\n  <body>
     <p>Hi.</p>
-    <p>The SAML certificate in your metadata registered in SWAMID \"%s\" (%s)%s.</p>
-    <p>The SWAMID SAML WebSSO Technology Profile requires that signing and
+    <p>The SAML certificate in your metadata registered in %s \"%s\" (%s)%s.</p>
+    <p>The %s requires that signing and
     encryption certificates MUST NOT be expired.<p>
     <p>You have received this email because you are either the technical and/or administrative contact.</p>
     <p>You can view your entity at <a href=\"%sadmin/?showEntity=%d\">%sadmin/?showEntity=%d</a> .</p>
-    <p>See our wiki on how you can roll the certificate without any disturbances on the service.</p>
-    <p><a href=\"https://wiki.sunet.se/display/SWAMID/Key+rollover\">https://wiki.sunet.se/display/SWAMID/Key+rollover</a>
-    <p>This is a message from the SWAMID SAML WebSSO metadata administration tool.<br>
+    <p>See our documentation on how you can roll the certificate without any disturbances on the service.</p>
+    <p><a href=\"%s\">%s</a>
+    <p>This is a message from the %s.<br>
     --<br>
-    On behalf of SWAMID Operations</p>
+    On behalf of %s</p>
   </body>\n</html>",
-  $displayName, $entityID, $expireStatus, $config->baseURL(), $id, $config->baseURL(), $id);
+  $federation['displayName'], $displayName, $entityID, $expireStatus,
+  $federation['rulesName'],
+  $config->baseURL(), $id, $config->baseURL(), $id,
+  $federation['roloverDocURL'], $federation['roloverDocURL'],
+  $federation['toolName'],
+  $federation['teamName']);
   $mailContacts->AltBody = sprintf("Hi.\n
-    \nThe SAML certificate in your metadata registered in SWAMID \"%s\" (%s)%s.
-    \nThe SWAMID SAML WebSSO Technology Profile requires that signing and encryption certificates MUST NOT be expired.
+    \nThe SAML certificate in your metadata registered in %s \"%s\" (%s)%s.
+    \nThe %s requires that signing and encryption certificates MUST NOT be expired.
     \nYou have received this email because you are either the technical and/or administrative contact.
     \nYou can view your entity at %sadmin/?showEntity=%d .
-    \nSee our wiki on how you can roll the certificate without any disturbances on the service.
-    \nhttps://wiki.sunet.se/display/SWAMID/Key+rollover
-    \nThis is a message from the SWAMID SAML WebSSO metadata administration tool.
+    \nSee our documentation on how you can roll the certificate without any disturbances on the service.
+    \n%s
+    \nThis is a message from the %s.
     --
-    On behalf of SWAMID Operations",
-    $displayName, $entityID, $expireStatus, $config->baseURL(), $id);
+    On behalf of %s",
+    $federation['displayName'], $displayName, $entityID, $expireStatus,
+    $federation['rulesName'],
+    $config->baseURL(), $id,
+    $federation['roloverDocURL'],
+    $federation['toolName'],
+    $federation['teamName']);
 
   try {
     $mailContacts->send();
@@ -538,6 +562,7 @@ function sendCertReminder($id, $entityID, $displayName, $maxStatus) {
 
 function sendOldUpdates($id, $entityID, $displayName, $removeDate, $weeks, $pending = true) {
   global $config, $mailContacts;
+  $federation = $config->getFederation();
 
   setupMail();
 
@@ -558,30 +583,33 @@ function sendOldUpdates($id, $entityID, $displayName, $removeDate, $weeks, $pend
     <p>You have received this email because you are the last person updating this entity.</p>
     %s<p>You can view or cancel your %s at
     <a href=\"%sadmin/?showEntity=%d\">%sadmin/?showEntity=%d</a> .</p>
-    <p>This is a message from the SWAMID SAML WebSSO metadata administration tool.<br>
+    <p>This is a message from the %s.<br>
     --<br>
-    On behalf of SWAMID Operations</p>
+    On behalf of %s</p>
   </body>\n</html>",
   $displayName, $entityID, $pending ? 'Pending' : 'Drafts', $weeks,
   $pending ? 'publication request' : 'draft', substr($removeDate,0,10),
-  $pending ? '<p>To get a change published forward this mail to operations@swamid.se</p>' : '',
+  $pending ? '<p>To get a change published forward this mail to ' . $federation['teamMail'] . '</p>' : '',
   $pending ? 'request' : 'draft',
-  $config->baseURL(), $id, $config->baseURL(), $id);
+  $config->baseURL(), $id, $config->baseURL(), $id,
+  $federation['toolName'], $federation['teamName']);
   $mailContacts->AltBody = sprintf("Hi.\n\nThe entity \"%s\" (%s) has been in %s for %d week(s).
     If nothing happens your %s will be removed short after %s.
     \nYou have received this email because you are the last person updating this entity.
     %s\nYou can view or cancel your %s at %sadmin/?showEntity=%d .
-    \nThis is a message from the SWAMID SAML WebSSO metadata administration tool.
+    \nThis is a message from the %s.
     --
-    On behalf of SWAMID Operations",
+    On behalf of %s",
     $displayName, $entityID, $pending ? 'Pending' : 'Drafts', $weeks,
     $pending ? 'publication request' : 'draft', substr($removeDate,0,10),
-    $pending ? "\nTo get a change published forward this mail to operations@swamid.se" : '',
+    $pending ? "\nTo get a change published forward this mail to " . $federation['teamMail'] : '',
     $pending ? 'request' : 'draft',
-    $config->baseURL(), $id);
+    $config->baseURL(), $id,
+    $federation['toolName'], $federation['teamName']);
 
   $shortEntityid = preg_replace('/^https?:\/\/([^:\/]*)\/.*/', '$1', $entityID);
-  $mailContacts->Subject  = sprintf ('Warning : SWAMID %s metadata for %s needs to be acted on',
+  $mailContacts->Subject  = sprintf ('Warning : %s %s metadata for %s needs to be acted on',
+    $federation['displayName'],
     $pending ? 'pending' : 'draft', $shortEntityid );
 
   try {

--- a/web/scripts/sendMailReminders.php
+++ b/web/scripts/sendMailReminders.php
@@ -480,7 +480,7 @@ function sendEntityConfirmation($id, $entityID, $displayName, $months) {
   try {
     $mailContacts->send();
   } catch (Exception $e) {
-    echo 'Message could not be sent to contacts.<br>';
+    echo 'Message could not be sent to contacts.<br>' . "\n";
   }
 }
 
@@ -532,7 +532,7 @@ function sendCertReminder($id, $entityID, $displayName, $maxStatus) {
   try {
     $mailContacts->send();
   } catch (Exception $e) {
-    echo 'Message could not be sent to contacts.<br>';
+    echo 'Message could not be sent to contacts.<br>' . "\n";
   }
 }
 
@@ -587,7 +587,7 @@ function sendOldUpdates($id, $entityID, $displayName, $removeDate, $weeks, $pend
   try {
     $mailContacts->send();
   } catch (Exception $e) {
-    echo 'Message could not be sent to contacts.<br>';
+    echo 'Message could not be sent to contacts.<br>' . "\n";
   }
 }
 
@@ -667,7 +667,7 @@ function sendImpsReminder($id, $name, $months) {
   try {
     $mailContacts->send();
   } catch (Exception $e) {
-    echo 'Message could not be sent to contacts.<br>';
+    echo 'Message could not be sent to contacts.<br>' . "\n";
   }
 }
 

--- a/web/scripts/updateTestResults.php
+++ b/web/scripts/updateTestResults.php
@@ -43,6 +43,11 @@ function parseJson($json) {
 
 function fetchJson() {
   global $config;
+  $rcURL = $config->getFederation()['releaseCheckResultsURL'];
+  if (!$rcURL) {
+    print("No release check test results URL configured, skipping test results download.\n");
+    return;
+  }
   $ch = curl_init();
   curl_setopt($ch, CURLOPT_HEADER, 0);
   curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
@@ -52,11 +57,8 @@ function fetchJson() {
   curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 
   curl_setopt($ch, CURLINFO_HEADER_OUT, 1);
-  if ($config->getMode() == 'QA') {
-    curl_setopt($ch, CURLOPT_URL, 'https://release-check.qa.swamid.se/metaDump.php');
-  } else {
-    curl_setopt($ch, CURLOPT_URL, 'https://release-check.swamid.se/metaDump.php');
-  }
+
+  curl_setopt($ch, CURLOPT_URL, $rcURL);
   $continue = true;
   while ($continue) {
     $output = curl_exec($ch);


### PR DESCRIPTION
Hi @btmattsson ,

I have found a few more places that needed customisation that I left out earlier.

Adding three new entries to config.php
```
'releaseCheckResultsURL' => 'https://release-check.swamid.se/metaDump.php',
'mdqBaseURL' => 'https://mds.swamid.se/entities/',
'roloverDocURL' => 'https://wiki.sunet.se/display/SWAMID/Key+rollover',
```

The first two will have a different value for the QA  environment to keep existing behaviour.

Otherwise, except for minor wording changes and/or fixes, this PR should be a no-op to your deployment.

Please let me know what you think.

Cheers,
Vlad
