### PR TITLE
Add Organisations API and import script

### DIFF
--- a/web/html/api/v1/organizations/index.php
+++ b/web/html/api/v1/organizations/index.php
@@ -1,0 +1,54 @@
+<?php
+//Load composer's autoloader
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+$config = new \metadata\Configuration();
+
+header('Content-type: application/json');
+
+$organizationHandler = $config->getDb()->prepare(
+  "SELECT `OrganizationInfo`.`id` AS orgId,
+      `OrganizationDisplayName`, `memberSince`, `notMemberAfter`,
+      COUNT(`Entities`.`id`) AS entitiesCount
+    FROM `OrganizationInfoData`, `OrganizationInfo`
+    LEFT JOIN `Entities` ON `Entities`.`OrganizationInfo_id` = `OrganizationInfo`.`id`
+    WHERE `OrganizationInfo`.`id` = `OrganizationInfoData`.`OrganizationInfo_id` AND
+      `lang` = 'en'
+    GROUP BY(orgId)
+    ORDER BY `OrganizationDisplayName`;");
+$organizationDataHandler = $config->getDb()->prepare(
+  'SELECT `lang`, `OrganizationName`, `OrganizationDisplayName`, `OrganizationURL`
+    FROM `OrganizationInfoData`
+    WHERE `OrganizationInfo_id` = :Id
+    ORDER BY `lang`;');
+
+$organizationHandler->execute();
+while ($organization = $organizationHandler->fetch(PDO::FETCH_ASSOC)) {
+  $organizationDataHandler->execute(array(\metadata\MetadataDisplay::BIND_ID => $organization['orgId']));
+
+  $orgObj = new \stdClass();
+  $orgInfoDataArray = array();
+
+  while ($orgInfoData = $organizationDataHandler->fetch(PDO::FETCH_ASSOC)) {
+    $orgInfoDataObj = new \stdClass();
+    $orgInfoDataObj->OrganizationName = $orgInfoData['OrganizationName'];
+    $orgInfoDataObj->OrganizationDisplayName = $orgInfoData['OrganizationDisplayName'];
+    $orgInfoDataObj->OrganizationURL = $orgInfoData['OrganizationURL'];
+    $orgInfoDataArray[$orgInfoData['lang']] = $orgInfoDataObj;
+    unset($orgInfoDataObj);
+  };
+  $orgObj->id = $organization['orgId'];
+  $orgObj->memberSince = $organization['memberSince'];
+  $orgObj->notMemberAfter = $organization['notMemberAfter'];
+  $orgObj->entitiesCount = $organization['entitiesCount'];
+  $today = date("Y-m-d");
+  $expired = $organization['notMemberAfter'] ? ( $today > $organization['notMemberAfter'] ) : false;
+  $notYetValid = $organization['memberSince'] ? ( $today < $organization['memberSince'] ) : false;
+  $orgObj->active = !$expired && !$notYetValid;
+  $orgObj->organizationInfoData = $orgInfoDataArray;
+  $orgsArray[] = $orgObj;
+  unset($orgObj);
+}
+$Obj = new \stdClass();
+$Obj->organizations = $orgsArray;
+print json_encode($Obj);

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -3338,7 +3338,7 @@ class MetadataDisplay extends Common {
     $organizationHandler = $this->config->getDb()->prepare(
       "SELECT `OrganizationInfo`.`id` AS orgId,
           `OrganizationDisplayName`, `memberSince`, `notMemberAfter`,
-          COUNT(`IMPS`.`id`) AS impsCount, COUNT(`Entities`.`id`) AS entitiesCount
+          COUNT(DISTINCT `IMPS`.`id`) AS impsCount, COUNT(DISTINCT `Entities`.`id`) AS entitiesCount
         FROM `OrganizationInfoData`, `OrganizationInfo`
         LEFT JOIN `IMPS` ON `IMPS`.`OrganizationInfo_id` = `OrganizationInfo`.`id`
         LEFT JOIN `Entities` ON `Entities`.`OrganizationInfo_id` = `OrganizationInfo`.`id`

--- a/web/scripts/importOrganizations.php
+++ b/web/scripts/importOrganizations.php
@@ -1,0 +1,94 @@
+<?php
+
+function usage() {
+  global $argv;
+  print "Usage:\n";
+  printf("    %s [--use-id] organisations-file.json\n", $argv[0]);
+  print "    Load a JSON file in the same format as produced by the organisations API\n";
+  print "    and import into the database.\n";
+  print "    Passing '-' as file name will use stdin instead.\n\n";
+  print "    With --use-id, also reuse the IDs of the organisation\n";
+  print "    (otherwise let the DB auto-assign).\n";
+}
+
+//Load composer's autoloader
+require_once __DIR__ . '/../html/vendor/autoload.php';
+
+$config = new \metadata\Configuration();
+
+if ( $argc <= 1 || ($argv[1] == '--use-id' && $argc <= 2 ) ) {
+   usage();
+   exit;
+}
+
+$use_id = $argv[1] == '--use-id';
+$filename = $argv[ $use_id ? 2 : 1];
+$raw_json_data = file_get_contents($filename == "-" ? 'php://stdin' : $filename);
+$organizations = json_decode($raw_json_data)->organizations;
+
+// Run the import within a transaction
+if (!$config->getDb()->beginTransaction()) {
+   print("Could not start DB transaction\n");
+   exit(1);
+}
+// Prepare variables and handler for OrganizationInfo records
+$org_id = 0;
+$memberSince = '';
+$notMemberAfter = '';
+
+$orgHandler = $config->getDb()->prepare('INSERT INTO OrganizationInfo
+    (' . ( $use_id ? 'id, ' : '') . 'memberSince, notMemberAfter)
+  VALUES
+    (' . ($use_id ? ':id ,' : '') . ':memberSince, :notMemberAfter)');
+if ($use_id) {
+  $orgHandler->bindParam(':id', $org_id);
+};
+$orgHandler->bindParam(':memberSince', $memberSince);
+$orgHandler->bindParam(':notMemberAfter', $notMemberAfter);
+
+// Prepare variables and handler for OrganizationInfoData records
+$org_lang = '';
+$org_name = '';
+$org_displayName = '';
+$org_url = '';
+
+$orgInfoDataHandler = $config->getDb()->prepare('INSERT INTO OrganizationInfoData
+    (OrganizationInfo_id, lang, OrganizationName, OrganizationDisplayName, OrganizationURL)
+  VALUES
+    (:OrgInfo_id, :lang, :OrgName, :OrgDisplayName, :OrgURL)');
+$orgInfoDataHandler->bindParam(':OrgInfo_id', $org_id);
+$orgInfoDataHandler->bindParam(':lang', $org_lang);
+$orgInfoDataHandler->bindParam(':OrgName', $org_name);
+$orgInfoDataHandler->bindParam(':OrgDisplayName', $org_displayName);
+$orgInfoDataHandler->bindParam(':OrgURL', $org_url);
+
+
+foreach ($organizations as $org) {
+  if ($org->active) {
+    printf("Found org %d\n", $org->id);
+    if ($use_id) {
+      $org_id = $org->id;
+    };
+    $memberSince = $org->memberSince;
+    $notMemberAfter = property_exists($org, 'notMemberAfter') ? $org->notMemberAfter : null;
+    $orgHandler->execute();
+
+    if (!$use_id) {
+      $org_id = $config->getDb()->lastInsertId();
+      printf("org got id %d\n", $org_id);
+    };
+
+    foreach ($org->organizationInfoData as $lang => $orgInfoData) {
+        $org_lang = $lang;
+        $org_name = $orgInfoData->OrganizationName;
+        $org_displayName = $orgInfoData->OrganizationDisplayName;
+        $org_url = $orgInfoData->OrganizationURL;
+        $orgInfoDataHandler->execute();
+    }
+  }
+}
+
+if (!$config->getDb()->commit()) {
+   print("Could not commit DB transaction\n");
+   exit(1);
+}


### PR DESCRIPTION
Hi @btmattsson ,

I am in the final stages of preparing to cut over to the metadata tool.

I am also looking at the dependencies our other applications have on our existing Federation Registry.

The Federation Registry provides an API endpoint that exports the list of Organisations, that the other applications use to populate their list of Organisations.

In this PR, I am adding a similar API endpoint to the Metadata Tool - in a format independent of our original tooling (I'll adjust our other apps to adapt).

I believe this export API would be generally useful to deployments of the tool.

I've also added an import script that can be used to bootstrap the list of organisations in a deployment of the metadata tool based on the export from another instance.  While meant as a one-off tool, I think it can still be generally useful (e.g., to repopulate a TEST environment).

Please let me know what you think.

Cheers,
Vlad
