### PR TITLE
Add support to record Service URL and publish list of services

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -158,3 +158,11 @@ Field | Type | Usage
 entity_id | int(10) | Foreign key (id) from Entities table
 type | tinyint(3) | Type of reminder ( 1 = Annual Confirmation)
 days | smallint(4) |
+
+## ServiceInfo
+
+Field | Type | Usage
+------|------| -----
+entity_id | INT UNSIGNED | Foreign key (id) from Entities table
+ServiceURL | TEXT | URL to access the service (by a user in a browser)
+enabled | TINYINT UNSIGNED | Boolean flag whether the service should be included in the Service Catalogue

--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -1265,6 +1265,15 @@ function move2Pending($entitiesId) {
           $shadowMetadata->importXML($publishedMetadata->xml());
           $shadowMetadata->updateFeedByValue($publishedMetadata->feedValue());
           $oldEntitiesId = $shadowMetadata->id();
+
+          # copy over also ServiceInfo
+          $serviceURL = '';
+          $enabled = 0;
+          $publishedMetadata->getServiceInfo($publishedMetadata->id(), $serviceURL, $enabled);
+          if ($serviceURL) {
+            $shadowMetadata->storeServiceInfo($oldEntitiesId, $serviceURL, $enabled);
+          }
+
           validateEntity($oldEntitiesId);
         } else {
           $mailContacts->Subject  = 'Info : New ' . $federation['displayName'] . HTML_TEXT_MEDFOR . $shortEntityid;
@@ -1872,6 +1881,15 @@ function move2Draft($entitiesId) {
     if (isset($_GET['action'])) {
       $draftMetadata = new \metadata\Metadata($entity['entityID'], 'New');
       $draftMetadata->importXML($entity['xml']);
+
+      # copy over also ServiceInfo
+      $serviceURL = '';
+      $enabled = 0;
+      $draftMetadata->getServiceInfo($entitiesId, $serviceURL, $enabled);
+      if ($serviceURL) {
+        $draftMetadata->storeServiceInfo($draftMetadata->id(), $serviceURL, $enabled);
+      }
+
       validateEntity($draftMetadata->id());
       $menuActive = 'new';
       $draftMetadata->copyResponsible($entitiesId);

--- a/web/html/api/v1/services/index.php
+++ b/web/html/api/v1/services/index.php
@@ -1,0 +1,50 @@
+<?php
+//Load composer's autoloader
+require_once __DIR__ . '/../../../vendor/autoload.php';
+
+$config = new \metadata\Configuration();
+
+header('Content-type: application/json');
+
+$servArray = array();
+
+$serviceHandler = $config->getDb()->prepare(
+  // Get all service marked for inclusion in service catalogue (ServiceURL recorded + marked as enabled).
+  // Decorate results with Organisation displayName and URL and also Service name, description and logo from SP MDUI.
+  // Limit to one result per service (as there might be multiple logos for a single language)
+  // Use LEFT JOIN to cover for logos or other Mdui information missing.
+  "SELECT e.id, e.entityID, si.serviceURL,
+            orgname.data AS o_name, orgurl.data AS o_url,
+            spname.data AS s_name, spdesc.data AS s_desc,
+            logo.data as logo_url, logo.width AS logo_width, logo.height AS logo_height
+       FROM Entities AS e
+       JOIN ServiceInfo AS si ON e.id = si.entity_id
+       LEFT JOIN Organization AS orgname on e.id = orgname.entity_id AND orgname.element = 'OrganizationDisplayName'
+       LEFT JOIN Organization AS orgurl on e.id = orgurl.entity_id AND orgurl.element = 'OrganizationURL'
+       LEFT JOIN Mdui AS spname ON e.id = spname.entity_id AND spname.element='DisplayName' AND spname.lang = 'en'
+       LEFT JOIN Mdui AS spdesc ON e.id = spdesc.entity_id AND spdesc.element='Description' AND spdesc.lang = 'en'
+       LEFT JOIN Mdui AS logo ON e.id = logo.entity_id AND logo.element='Logo' AND logo.lang='en'
+       WHERE e.status = 1 AND e.isSP = 1 AND si.enabled GROUP BY id ORDER BY entityID;"
+    );
+
+$serviceHandler->execute();
+while ($service = $serviceHandler->fetch(PDO::FETCH_ASSOC)) {
+
+  $servObj = new \stdClass();
+
+  $servObj->id = $service['id'];
+  $servObj->entityID = $service['entityID'];
+  $servObj->displayName = $service['s_name'];
+  $servObj->description = $service['s_desc'];
+  $servObj->url = $service['serviceURL'];
+  $servObj->organization = $service['o_name'];
+  $servObj->organizationURL = $service['o_url'];
+  $servObj->logo_URL = $service['logo_url'];
+  $servObj->logo_width = $service['logo_width'];
+  $servObj->logo_height = $service['logo_height'];
+  $servArray[] = $servObj;
+  unset($servObj);
+}
+$Obj = new \stdClass();
+$Obj->services = $servArray;
+print json_encode($Obj);

--- a/web/html/config.template.php
+++ b/web/html/config.template.php
@@ -116,6 +116,8 @@ $federation = array(
   'checkOrganization' => false,
   # Should we clean up saml:Attribute elements from IDPSSODescriptors
   'cleanAttribuesFromIDPSSODescriptor' => true,
+  # Whether to offer UI to store Service Catalogue info (Service URL, ...)
+  'storeServiceInfo' => true,
   # URL to get release-check test results from - or empty string if not used
   'releaseCheckResultsURL' => 'https://release-check.swamid.se/metaDump.php',
   # Base URL for MDQ - or empty string if not available

--- a/web/html/src/Common.php
+++ b/web/html/src/Common.php
@@ -687,4 +687,66 @@ class Common {
     }
     return $uuInfo;
   }
+
+  /**
+   * Get Service Info record associated with the given Entity
+   *
+   * @param int $dbIdNr Numeric ID of the entity to get the service info for
+   *
+   * @param string &$serviceURL Service URL retrieved from the ServiceInfo record.
+   *
+   * @param bool &$enabled Whether the service should be included in the Service Catalogue
+   *
+   * @return void
+   */
+
+  public function getServiceInfo($dbIdNr, &$serviceURL, &$enabled) {
+    $serviceURL = '';
+    $enabled = 0;
+    $serviceInfoHandler = $this->config->getDb()->prepare("SELECT `ServiceURL`, `enabled` FROM `ServiceInfo` WHERE `entity_id` = :Id;");
+    $serviceInfoHandler->bindParam(self::BIND_ID, $dbIdNr);
+    $serviceInfoHandler->execute();
+    if ($srvi = $serviceInfoHandler->fetch(PDO::FETCH_ASSOC)) {
+      $serviceURL = $srvi['ServiceURL'];
+      $enabled = $srvi['enabled'];
+    }
+  }
+
+  /**
+   * Stores Service Info record associated with the given Entity
+   *
+   * @param int $dbIdNr Numeric ID of the entity to store the service info for
+   *
+   * @param string $serviceURL Service URL to store in the ServiceInfo record.
+   *
+   * @param bool $enabled Whether the service should be included in the Service Catalogue
+   *
+   * @return void
+   */
+
+  public function storeServiceInfo($dbIdNr, $serviceURL, $enabled = true) {
+    $strSrvInfHandler = $this->config->getDb()->prepare(
+        'INSERT INTO `ServiceInfo` ( `entity_id`, `ServiceURL`, `enabled`) ' .
+        'VALUES (:Id, :ServiceURL, :enabled) ' .
+        'ON DUPLICATE KEY UPDATE `ServiceURL` = :ServiceURL, `enabled` = :enabled;');
+    $strSrvInfHandler->bindParam(self::BIND_ID, $dbIdNr);
+    $strSrvInfHandler->bindParam(':ServiceURL', $serviceURL);
+    $strSrvInfHandler->bindParam(':enabled', $enabled);
+    $strSrvInfHandler->execute();
+  }
+
+  /**
+   * Removes Service Info record associated with the given Entity
+   *
+   * @param int $dbIdNr Numeric ID of the entity to delete the service info for
+   *
+   * @return void
+   */
+
+  public function removeServiceInfo($dbIdNr) {
+    $delSrvInfHandler = $this->config->getDb()->prepare("DELETE FROM `ServiceInfo` WHERE `entity_id` = :Id;");
+    $delSrvInfHandler->bindParam(self::BIND_ID, $dbIdNr);
+    $delSrvInfHandler->execute();
+  }
+
 }

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -86,7 +86,6 @@ class Configuration {
       'rulesSectsBoth', 'rulesSectsIdP', 'rulesSectsSP',
       'rulesInfoBoth', 'rulesInfoIdP', 'rulesInfoSP',
       'swamid_assurance', 'checkOrganization', 'cleanAttribuesFromIDPSSODescriptor',
-      'storeServiceInfo',
       'releaseCheckResultsURL', 'mdqBaseURL');
 
     $defaultValuesFederation = array(

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -86,6 +86,7 @@ class Configuration {
       'rulesSectsBoth', 'rulesSectsIdP', 'rulesSectsSP',
       'rulesInfoBoth', 'rulesInfoIdP', 'rulesInfoSP',
       'swamid_assurance', 'checkOrganization', 'cleanAttribuesFromIDPSSODescriptor',
+      'storeServiceInfo',
       'releaseCheckResultsURL', 'mdqBaseURL');
 
     foreach ($reqParams as $param) {

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -89,6 +89,10 @@ class Configuration {
       'storeServiceInfo',
       'releaseCheckResultsURL', 'mdqBaseURL');
 
+    $defaultValuesFederation = array(
+      'storeServiceInfo' => false,
+    );
+
     foreach ($reqParams as $param) {
       if (! isset(${$param})) {
         printf ('Missing %s in config.php<br>', $param);
@@ -99,7 +103,7 @@ class Configuration {
     $this->checkParams($db, $reqParamsDB, 'db');
     $this->checkParams($smtp, $reqParamsSmtp, 'smtp');
 
-    $this->checkParams($federation, $reqParamsFederation, 'federation');
+    $this->checkParams($federation, $reqParamsFederation, 'federation', $defaultValuesFederation);
     if (! isset($federation['extend'])) {
       $federation['extend'] = '';
     }
@@ -172,7 +176,12 @@ class Configuration {
    *
    * @return void
    */
-  private function checkParams($checkParam, $reqParams, $nameOfParam) {
+  private function checkParams(&$checkParam, $reqParams, $nameOfParam, $defaultValues = array()) {
+    foreach ($defaultValues as $param => $defaultValue) {
+      if (! isset($checkParam[$param])) {
+        $checkParam[$param] = $defaultValue;
+      }
+    }
     foreach ($reqParams as $param) {
       if (! isset($checkParam[$param])) {
         printf ('Missing $%s[%s] in config.php<br>', $nameOfParam, $param);

--- a/web/html/src/Configuration.php
+++ b/web/html/src/Configuration.php
@@ -202,7 +202,7 @@ class Configuration {
       } catch(PDOException $e) {
         $this->createTables();
         // Don't forget to update version in createTables!!!
-        $dbVersion = 2;
+        $dbVersion = 3;
       }
     }
     if ($dbVersion < 2) {
@@ -282,6 +282,20 @@ class Configuration {
       $this->db->query('ALTER TABLE `Mdui` DROP COLUMN `id`;');
       $this->db->query(
         "UPDATE `params` SET `value` = '2' WHERE `id` = 'dbVersion';");
+      $this->db->query('COMMIT;');
+    }
+
+    if ($dbVersion < 3) {
+      $this->db->query('START TRANSACTION;');
+      $this->db->query('CREATE TABLE `ServiceInfo` (
+        `entity_id` int(10) unsigned NOT NULL,
+        `ServiceURL` text NOT NULL,
+        `enabled` tinyint(3) unsigned DEFAULT NULL,
+        PRIMARY KEY (`entity_id`),
+        CONSTRAINT `ServiceInfo_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `Entities` (`id`) ON DELETE CASCADE
+      );');
+      $this->db->query(
+        "UPDATE `params` SET `value` = '3' WHERE `id` = 'dbVersion';");
       $this->db->query('COMMIT;');
     }
   }
@@ -583,7 +597,7 @@ class Configuration {
       `id` varchar(20) DEFAULT NULL,
       `value` text DEFAULT NULL
     );');
-    $this->db->query("INSERT INTO `params` (`id`, `value`) VALUES ('dbVersion', '2');");
+    $this->db->query("INSERT INTO `params` (`id`, `value`) VALUES ('dbVersion', '3');");
 
     $this->db->query('CREATE TABLE `DiscoveryResponse` (
       `entity_id` int(10) unsigned NOT NULL,
@@ -591,6 +605,14 @@ class Configuration {
       `location` text DEFAULT NULL,
       PRIMARY KEY (`entity_id`,`index`),
       CONSTRAINT `DiscoveryResponse_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `Entities` (`id`) ON DELETE CASCADE
+    );');
+
+    $this->db->query('CREATE TABLE `ServiceInfo` (
+      `entity_id` int(10) unsigned NOT NULL,
+      `ServiceURL` text NOT NULL,
+      `enabled` tinyint(3) unsigned DEFAULT NULL,
+      PRIMARY KEY (`entity_id`),
+      CONSTRAINT `ServiceInfo_ibfk_1` FOREIGN KEY (`entity_id`) REFERENCES `Entities` (`id`) ON DELETE CASCADE
     );');
   }
 

--- a/web/html/src/Metadata.php
+++ b/web/html/src/Metadata.php
@@ -152,6 +152,15 @@ class Metadata extends Common {
       $this->dbIdNr = $this->config->getDb()->lastInsertId();
       $this->status = 3;
       $this->copyResponsible($oldDbNr);
+
+      # copy over ServiceInfo
+      $serviceURL = '';
+      $enabled = 0;
+      $this->getServiceInfo($oldDbNr, $serviceURL, $enabled);
+      if ($serviceURL) {
+        $this->storeServiceInfo($this->dbIdNr, $serviceURL, $enabled);
+      }
+
       return $this->dbIdNr;
     } else {
       return false;
@@ -634,6 +643,16 @@ class Metadata extends Common {
         $updateEntityConfirmationHandler->execute();
         # copy over organizationInfoId from pending
         $updateEntitiesHandler->execute(array(self::BIND_ID => $publishedEntity['id'], ':OrgId' => $this->organizationInfoId ));
+
+        # copy over ServiceInfo
+        $serviceURL = '';
+        $enabled = 0;
+        $this->getServiceInfo($this->dbIdNr, $serviceURL, $enabled);
+        if ($serviceURL) {
+          $this->storeServiceInfo($publishedEntity['id'], $serviceURL, $enabled);
+        } else {
+          $this->removeServiceInfo($publishedEntity['id']);
+        }
       }
       # Move entity to status PendingPublished
       $entityUpdateHandler = $this->config->getDb()->prepare('UPDATE `Entities`

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -1193,7 +1193,7 @@ class MetadataDisplay extends Common {
     $data = $serviceURL ? htmlspecialchars($serviceURL) . $enabled_txt : 'Not provided';
     # Allow updating the ServiceInfo if the user is an admin
     # (but not for the "old" metadata, and skip if we show the edit icon anyway)
-    $extra = !$allowEdit && $added && $userLevel > 19 ? sprintf(' <a href="./?edit=SPServiceInfo&Entity=%d&oldEntity=%d"><button>Update</button></a>', $entityId, $otherEntity) : '';
+    $extra = !$allowEdit && $added && $userLevel > 19 ? sprintf(' <a href="./?edit=SPServiceInfo&Entity=%d&oldEntity=%d"><button>Update</button></a>', $entityId, $otherEntityId) : '';
     printf ('%s                <b>Service URL</b>', "\n");
     printf ('%s                <ul>', "\n");
     printf ('%s                  <li><span class="text-%s">%s</span>%s</li>', "\n", $state, $data, $extra);

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -1194,7 +1194,7 @@ class MetadataDisplay extends Common {
     # Allow updating the ServiceInfo if the user is an admin
     # (but not for the "old" metadata, and skip if we show the edit icon anyway)
     $extra = !$allowEdit && $added && $userLevel > 19 ? sprintf(' <a href="./?edit=SPServiceInfo&Entity=%d&oldEntity=%d"><button>Update</button></a>', $entityId, $otherEntityId) : '';
-    printf ('%s                <b>Service URL</b>', "\n");
+    printf ('%s                <b>URL to access this service (for use in service catalog)</b>', "\n");
     printf ('%s                <ul>', "\n");
     printf ('%s                  <li><span class="text-%s">%s</span>%s</li>', "\n", $state, $data, $extra);
     printf ('%s                </ul>', "\n");

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -867,10 +867,10 @@ class MetadataDisplay extends Common {
     if ($config->getFederation()['storeServiceInfo']) {
         $this->showCollapse('ServiceInfo', 'ServiceInfo_SPSSO', false, 1, true, $allowEdit ? 'SPServiceInfo' : false, $entityId, $oldEntityId);
 
-        $this->showServiceInfo($entityId, $oldEntityId, true);
+        $this->showServiceInfo($entityId, $oldEntityId, $allowEdit, true);
         if ($oldEntityId != 0 ) {
           $this->showNewCol(1);
-          $this->showServiceInfo($oldEntityId, $entityId);
+          $this->showServiceInfo($oldEntityId, $entityId, $allowEdit);
         }
         $this->showCollapseEnd('ServiceInfo_SPSSO', 1);
     }
@@ -1151,11 +1151,15 @@ class MetadataDisplay extends Common {
    *
    * @param int $otherEntityId Id of entity to compare with
    *
+   * @param bool $allowEdit whether editing is allowed
+   *
    * @param bool $added if this is the added or Old entity
    *
    * @return void
    */
-  private function showServiceInfo($entityId, $otherEntityId=0, $added = false) {
+  private function showServiceInfo($entityId, $otherEntityId=0, $allowEdit, $added = false) {
+    global $userLevel;
+
     $serviceInfoHandler = $this->config->getDb()->prepare("SELECT `ServiceURL`, `enabled`
       FROM `ServiceInfo` WHERE `entity_id` = :Id;");
 
@@ -1187,9 +1191,12 @@ class MetadataDisplay extends Common {
       $state = 'dark';
     }
     $data = $serviceURL ? htmlspecialchars($serviceURL) . ($enabled ? ' (active)' : ' (inactive)' ) : 'Not provided';
+    # Allow updating the ServiceInfo if the user is an admin
+    # (but not for the "old" metadata, and skip if we show the edit icon anyway)
+    $extra = !$allowEdit && $added && $userLevel > 19 ? sprintf(' <a href="./?edit=SPServiceInfo&Entity=%d&oldEntity=%d"><button>Update</button></a>', $entityId, $oldEntity) : '';
     printf ('%s                <b>Service URL</b>', "\n");
     printf ('%s                <ul>', "\n");
-    printf ('%s                  <li><span class="text-%s">%s</span></li>', "\n", $state, $data);
+    printf ('%s                  <li><span class="text-%s">%s</span>%s</li>', "\n", $state, $data, $extra);
     printf ('%s                </ul>', "\n");
   }
 

--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -1157,7 +1157,7 @@ class MetadataDisplay extends Common {
    *
    * @return void
    */
-  private function showServiceInfo($entityId, $otherEntityId=0, $allowEdit, $added = false) {
+  private function showServiceInfo($entityId, $otherEntityId=0, $allowEdit=false, $added = false) {
     global $userLevel;
 
     $serviceInfoHandler = $this->config->getDb()->prepare("SELECT `ServiceURL`, `enabled`
@@ -1176,7 +1176,6 @@ class MetadataDisplay extends Common {
     $enabled = false;
     $serviceInfoHandler->bindParam(self::BIND_ID, $entityId);
     $serviceInfoHandler->execute();
-    $showEndUL = false;
     if ($srvi = $serviceInfoHandler->fetch(PDO::FETCH_ASSOC)) {
       $serviceURL = $srvi['ServiceURL'];
       $enabled = $srvi['enabled'];
@@ -1190,10 +1189,11 @@ class MetadataDisplay extends Common {
     } else {
       $state = 'dark';
     }
-    $data = $serviceURL ? htmlspecialchars($serviceURL) . ($enabled ? ' (active)' : ' (inactive)' ) : 'Not provided';
+    $enabled_txt = $enabled ? ' (active)' : ' (inactive)';
+    $data = $serviceURL ? htmlspecialchars($serviceURL) . $enabled_txt : 'Not provided';
     # Allow updating the ServiceInfo if the user is an admin
     # (but not for the "old" metadata, and skip if we show the edit icon anyway)
-    $extra = !$allowEdit && $added && $userLevel > 19 ? sprintf(' <a href="./?edit=SPServiceInfo&Entity=%d&oldEntity=%d"><button>Update</button></a>', $entityId, $oldEntity) : '';
+    $extra = !$allowEdit && $added && $userLevel > 19 ? sprintf(' <a href="./?edit=SPServiceInfo&Entity=%d&oldEntity=%d"><button>Update</button></a>', $entityId, $otherEntity) : '';
     printf ('%s                <b>Service URL</b>', "\n");
     printf ('%s                <ul>', "\n");
     printf ('%s                  <li><span class="text-%s">%s</span>%s</li>', "\n", $state, $data, $extra);

--- a/web/html/src/MetadataEdit.php
+++ b/web/html/src/MetadataEdit.php
@@ -1239,41 +1239,24 @@ class MetadataEdit extends Common {
       } else {
         switch ($_POST['action']) {
           case 'Add' :
-            $strSrvInfHandler = $this->config->getDb()->prepare(
-                'INSERT INTO `ServiceInfo` ( `entity_id`, `ServiceURL`, `enabled`) ' .
-                'VALUES (:Id, :ServiceURL, :enabled) ' .
-                'ON DUPLICATE KEY UPDATE `ServiceURL` = :ServiceURL, `enabled` = :enabled;');
-            $strSrvInfHandler->bindParam(self::BIND_ID, $this->dbIdNr);
-            $strSrvInfHandler->bindParam(':ServiceURL', $serviceURL);
-            $strSrvInfHandler->bindParam(':enabled', $enabled);
-            $strSrvInfHandler->execute();
+            $this->storeServiceInfo($this->dbIdNr, $serviceURL, $enabled);
             $this->addURL($serviceURL, 1);
             break;
           case 'Delete' :
-            $delSrvInfHandler = $this->config->getDb()->prepare("DELETE FROM `ServiceInfo` WHERE `entity_id` = :Id;");
-            $delSrvInfHandler->bindParam(self::BIND_ID, $this->dbIdNr);
-            $delSrvInfHandler->execute();
+            $this->removeServiceInfo($this->dbIdNr);
             break;
           default :
         }
       }
     }
-    $serviceInfoHandler = $this->config->getDb()->prepare("SELECT `ServiceURL`, `enabled` FROM `ServiceInfo` WHERE `entity_id` = :Id;");
     $oldServiceURL = '';
     $oldEnabled = 0;
-    $serviceInfoHandler->bindParam(self::BIND_ID, $this->dbOldIdNr);
-    $serviceInfoHandler->execute();
-    if ($srvi = $serviceInfoHandler->fetch(PDO::FETCH_ASSOC)) {
-      $oldServiceURL = $srvi['ServiceURL'];
-      $oldEnabled = $srvi['enabled'];
-    }
+    $this->getServiceInfo($this->dbOldIdNr, $oldServiceURL, $oldEnabled);
+
     $serviceURL = '';
     $enabled = 0;
-    $serviceInfoHandler->bindParam(self::BIND_ID, $this->dbIdNr);
-    $serviceInfoHandler->execute();
-    if ($srvi = $serviceInfoHandler->fetch(PDO::FETCH_ASSOC)) {
-      $serviceURL = $srvi['ServiceURL'];
-      $enabled = $srvi['enabled'];
+    $this->getServiceInfo($this->dbIdNr, $serviceURL, $enabled);
+    if ($serviceURL) {
       if ($serviceURL == $oldServiceURL && $enabled == $oldEnabled) {
         $state = 'dark';
       } else {

--- a/web/html/src/MetadataEdit.php
+++ b/web/html/src/MetadataEdit.php
@@ -1262,7 +1262,8 @@ class MetadataEdit extends Common {
       } else {
         $state = 'success';
       }
-      $data = $serviceURL ? htmlspecialchars($serviceURL) . ($enabled ? ' (active)' : ' (inactive)' ) : 'Not provided';
+      $enabled_txt = $enabled ? ' (active)' : ' (inactive)';
+      $data = $serviceURL ? htmlspecialchars($serviceURL) .  $enabled_txt : 'Not provided';
       printf ('%s        <b>Service URL</b>', "\n");
       printf ('%s        <ul>', "\n");
       printf ('%s          <li><span class="text-%s">%s</span></li>', "\n", $state, $data);

--- a/web/html/src/MetadataEdit.php
+++ b/web/html/src/MetadataEdit.php
@@ -1264,7 +1264,7 @@ class MetadataEdit extends Common {
       }
       $enabled_txt = $enabled ? ' (active)' : ' (inactive)';
       $data = $serviceURL ? htmlspecialchars($serviceURL) .  $enabled_txt : 'Not provided';
-      printf ('%s        <b>Service URL</b>', "\n");
+      printf ('%s        <b>URL to access this service (for use in service catalog)</b>', "\n");
       printf ('%s        <ul>', "\n");
       printf ('%s          <li><span class="text-%s">%s</span></li>', "\n", $state, $data);
       printf ('%s        </ul>', "\n");
@@ -1272,7 +1272,7 @@ class MetadataEdit extends Common {
     printf('
         <form action="?edit=SPServiceInfo&Entity=%d&oldEntity=%d" method="POST">
           <div class="row">
-            <div class="col-3">Service URL: </div>
+            <div class="col-3">URL to access this service: </div>
             <div class="col-9"><input type="text" name="ServiceURL" value="%s" size="40"></div>
           </div>
           <div class="row">
@@ -1307,7 +1307,7 @@ class MetadataEdit extends Common {
         $copy_open = '';
         $copy_close = '';
       }
-      printf ('%s        <b>Service URL</b>', "\n");
+      printf ('%s        <b>URL to access this service (for use in service catalog)</b>', "\n");
       printf ('%s        <ul>', "\n");
       printf ('%s          <li>%s<span class="text-%s">%s</span>%s</li>', "\n", $copy_open, $state, $data, $copy_close);
       printf ('%s        </ul>', "\n");

--- a/web/html/src/MetadataEdit.php
+++ b/web/html/src/MetadataEdit.php
@@ -96,6 +96,9 @@ class MetadataEdit extends Common {
       case 'SPMDUI' :
         $this->editMDUI('SPSSO');
         break;
+      case 'SPServiceInfo' :
+        $this->editServiceInfo();
+        break;
       case 'IdPKeyInfo' :
         $this->editKeyInfo('IDPSSO');
         break;
@@ -1209,6 +1212,121 @@ class MetadataEdit extends Common {
         }
       }
       print "\n" . self::HTML_END_UL;
+    }
+    print self::HTML_END_DIV_COL_ROW;
+  }
+
+  /**
+   * Edit ServiceInfo
+   *
+   * @return void
+   */
+  private function editServiceInfo() {
+    printf (self::HTML_START_DIV_ROW_COL, "\n", "\n");
+    if (isset($_POST['action'])) {
+      $error = '';
+      if (isset($_POST['ServiceURL']) && filter_var($_POST['ServiceURL'], FILTER_VALIDATE_URL) ) {
+        $serviceURL = trim($_POST['ServiceURL']);
+      } else {
+        if ($_POST['action'] == "Add" ) {
+          $error .= '<br>' . ( trim($_POST['ServiceURL']) == '' ? 'Value is empty' : 'Value is not a valid URL');
+        }
+        $serviceURL = '';
+      }
+      $enabled = $_POST['enabled'] == '1' ? 1 : 0;
+      if ($error) {
+        printf (self::HTML_DIV_CLASS_ALERT_DANGER, $error);
+      } else {
+        switch ($_POST['action']) {
+          case 'Add' :
+            $strSrvInfHandler = $this->config->getDb()->prepare(
+                'INSERT INTO `ServiceInfo` ( `entity_id`, `ServiceURL`, `enabled`) ' .
+                'VALUES (:Id, :ServiceURL, :enabled) ' .
+                'ON DUPLICATE KEY UPDATE `ServiceURL` = :ServiceURL, `enabled` = :enabled;');
+            $strSrvInfHandler->bindParam(self::BIND_ID, $this->dbIdNr);
+            $strSrvInfHandler->bindParam(':ServiceURL', $serviceURL);
+            $strSrvInfHandler->bindParam(':enabled', $enabled);
+            $strSrvInfHandler->execute();
+            $this->addURL($serviceURL, 1);
+            break;
+          case 'Delete' :
+            $delSrvInfHandler = $this->config->getDb()->prepare("DELETE FROM `ServiceInfo` WHERE `entity_id` = :Id;");
+            $delSrvInfHandler->bindParam(self::BIND_ID, $this->dbIdNr);
+            $delSrvInfHandler->execute();
+            break;
+          default :
+        }
+      }
+    }
+    $serviceInfoHandler = $this->config->getDb()->prepare("SELECT `ServiceURL`, `enabled` FROM `ServiceInfo` WHERE `entity_id` = :Id;");
+    $oldServiceURL = '';
+    $oldEnabled = 0;
+    $serviceInfoHandler->bindParam(self::BIND_ID, $this->dbOldIdNr);
+    $serviceInfoHandler->execute();
+    if ($srvi = $serviceInfoHandler->fetch(PDO::FETCH_ASSOC)) {
+      $oldServiceURL = $srvi['ServiceURL'];
+      $oldEnabled = $srvi['enabled'];
+    }
+    $serviceURL = '';
+    $enabled = 0;
+    $serviceInfoHandler->bindParam(self::BIND_ID, $this->dbIdNr);
+    $serviceInfoHandler->execute();
+    if ($srvi = $serviceInfoHandler->fetch(PDO::FETCH_ASSOC)) {
+      $serviceURL = $srvi['ServiceURL'];
+      $enabled = $srvi['enabled'];
+      if ($serviceURL == $oldServiceURL && $enabled == $oldEnabled) {
+        $state = 'dark';
+      } else {
+        $state = 'success';
+      }
+      $data = $serviceURL ? htmlspecialchars($serviceURL) . ($enabled ? ' (active)' : ' (inactive)' ) : 'Not provided';
+      printf ('%s        <b>Service URL</b>', "\n");
+      printf ('%s        <ul>', "\n");
+      printf ('%s          <li><span class="text-%s">%s</span></li>', "\n", $state, $data);
+      printf ('%s        </ul>', "\n");
+    }
+    printf('
+        <form action="?edit=SPServiceInfo&Entity=%d&oldEntity=%d" method="POST">
+          <div class="row">
+            <div class="col-3">Service URL: </div>
+            <div class="col-9"><input type="text" name="ServiceURL" value="%s" size="40"></div>
+          </div>
+          <div class="row">
+            <div class="col-3">Include in Service Catalogue: </div>
+            <div class="col-9"><input type="checkbox" name="enabled" value="1"%s></div>
+          </div>
+          <button type="submit" name="action" value="Add">Add/Update</button>
+          <button type="submit" name="action" value="Delete">Delete</button>
+        </form>
+        <a href="./?validateEntity=%d"><button>Back</button></a>
+      </div><!-- end col -->
+      <div class="col">',
+      $this->dbIdNr, $this->dbOldIdNr, htmlspecialchars($serviceURL), $enabled ? " checked" : '', $this->dbIdNr);
+
+    if ($oldServiceURL) {
+      if ($serviceURL == $oldServiceURL && $enabled == $oldEnabled) {
+        $state = 'dark';
+      } else {
+        $state = 'danger';
+      }
+      // no need to test again of oldServiceURL is non-empty
+      $data = htmlspecialchars($oldServiceURL) . ($oldEnabled ? ' (active)' : ' (inactive)' );
+      if ($state == 'danger') {
+        $copy_open = sprintf('<form action="?edit=SPServiceInfo&Entity=%d&oldEntity=%d" method="POST" name="copyServiceInfo">' .
+            '<input type="hidden" name="action" value="Add">' .
+            '<input type="hidden" name="ServiceURL" value="%s">' .
+            '<input type="hidden" name="enabled" value="%s">' .
+            '<a href="#" onClick="document.forms.copyServiceInfo.submit();">[copy]</a> ',
+          $this->dbIdNr, $this->dbOldIdNr, htmlspecialchars($oldServiceURL), $oldEnabled);
+        $copy_close = '</form>';
+      } else {
+        $copy_open = '';
+        $copy_close = '';
+      }
+      printf ('%s        <b>Service URL</b>', "\n");
+      printf ('%s        <ul>', "\n");
+      printf ('%s          <li>%s<span class="text-%s">%s</span>%s</li>', "\n", $copy_open, $state, $data, $copy_close);
+      printf ('%s        </ul>', "\n");
     }
     print self::HTML_END_DIV_COL_ROW;
   }

--- a/web/scripts/importOrganizations.php
+++ b/web/scripts/importOrganizations.php
@@ -28,7 +28,7 @@ $organizations = json_decode(json: $raw_json_data, flags: JSON_THROW_ON_ERROR)->
 
 // Run the import within a transaction
 if (!$config->getDb()->beginTransaction()) {
-   print("Could not start DB transaction\n");
+   print "Could not start DB transaction\n";
    exit(1);
 }
 // Prepare variables and handler for OrganizationInfo records
@@ -89,6 +89,6 @@ foreach ($organizations as $org) {
 }
 
 if (!$config->getDb()->commit()) {
-   print("Could not commit DB transaction\n");
+   print "Could not commit DB transaction\n";
    exit(1);
 }

--- a/web/scripts/importOrganizations.php
+++ b/web/scripts/importOrganizations.php
@@ -24,7 +24,7 @@ if ( $argc <= 1 || ($argv[1] == '--use-id' && $argc <= 2 ) ) {
 $use_id = $argv[1] == '--use-id';
 $filename = $argv[ $use_id ? 2 : 1];
 $raw_json_data = file_get_contents($filename == "-" ? 'php://stdin' : $filename);
-$organizations = json_decode($raw_json_data)->organizations;
+$organizations = json_decode(json: $raw_json_data, flags: JSON_THROW_ON_ERROR)->organizations;
 
 // Run the import within a transaction
 if (!$config->getDb()->beginTransaction()) {

--- a/web/scripts/importServices.php
+++ b/web/scripts/importServices.php
@@ -25,7 +25,7 @@ $services = json_decode(json: $raw_json_data, flags: JSON_THROW_ON_ERROR)->servi
 
 // Run the import within a transaction
 if (!$config->getDb()->beginTransaction()) {
-   print("Could not start DB transaction\n");
+   print "Could not start DB transaction\n";
    exit(1);
 }
 
@@ -41,6 +41,6 @@ foreach ($services as $service) {
 }
 
 if (!$config->getDb()->commit()) {
-   print("Could not commit DB transaction\n");
+   print "Could not commit DB transaction\n";
    exit(1);
 }

--- a/web/scripts/importServices.php
+++ b/web/scripts/importServices.php
@@ -1,0 +1,46 @@
+<?php
+
+function usage() {
+  global $argv;
+  print "Usage:\n";
+  printf("    %s service-file.json\n", $argv[0]);
+  print "    Load a JSON file in the same format as produced by the Services API\n";
+  print "    and mport service URLs into the database.\n";
+  print "    Passing '-' as file name will use stdin instead.\n\n";
+}
+
+//Load composer's autoloader
+require_once __DIR__ . '/../html/vendor/autoload.php';
+
+$config = new \metadata\Configuration();
+
+if ( $argc <= 1 ) {
+   usage();
+   exit;
+}
+
+$filename = $argv[1];
+$raw_json_data = file_get_contents($filename == "-" ? 'php://stdin' : $filename);
+$services = json_decode(json: $raw_json_data, flags: JSON_THROW_ON_ERROR)->services;
+
+// Run the import within a transaction
+if (!$config->getDb()->beginTransaction()) {
+   print("Could not start DB transaction\n");
+   exit(1);
+}
+
+foreach ($services as $service) {
+  $metadata = new \metadata\Metadata($service->entityID, 'Prod');
+  if ($metadata->id()) {
+    printf("Storing service URL %s for %s into %d\n",
+        $service->url, $service->entityID, $metadata->id());
+    $metadata->storeServiceInfo($metadata->id(), $service->url, 1);
+  } else {
+    printf("Unknown entityID %s\n", $service->entityID);
+  }
+}
+
+if (!$config->getDb()->commit()) {
+   print("Could not commit DB transaction\n");
+   exit(1);
+}


### PR DESCRIPTION
@btmattsson thanks for your initial feedback in our email discussion.

Please let me know what you think of this implementation of the idea.

This PR:
* adds a ServiceInfo DB table that records for SPs the *Service URL* and a boolean flag whether the service should be published in the service catalogue
* adds a display + edit functionality into entity view
* adds a config  entry to turn the UI features on or off (default off)
* adds an API export endpoint
* adds an import script

The URLs are added to list of URLs to check with `addURL()`.

The service info is handled in `createDraft()` and `movePublishedPending()` methods to copy between entities.

Please let me know what you think.

Cheers,
Vlad