### PR TITLE
Move info message about AA from MetaDataDisplay to ValidateSWAMID

### DIFF
--- a/web/html/src/MetadataDisplay.php
+++ b/web/html/src/MetadataDisplay.php
@@ -294,10 +294,6 @@ class MetadataDisplay extends Display\Common {
         </ul>%s      </div>%s    </div>', "\n", "\n", str_ireplace("\n", "</li>\n          <li>", trim($warnings)), "\n", "\n");
       }
 
-      if ($entity['isAA']) {
-        $notice .= 'The AttributeAuthority is a part of the Identity Provider and follow the same rules for SWAMID Tech 5.1.21 and 5.2.x.<br>';
-        $notice .= "If the AttributeAuthority part of the entity is not used SWAMID recommends that is removed.\n";
-      }
       if ($entity['validationOutput'] != '') {
         $notice .= $entity['validationOutput'];
       }

--- a/web/html/src/ValidateSWAMID.php
+++ b/web/html/src/ValidateSWAMID.php
@@ -76,6 +76,8 @@ class ValidateSWAMID extends Validate {
     if ($this->isAA) {
       // 5.1.20, 5.2.x
       $this->checkRequiredSAMLcertificates('AttributeAuthority');
+      $this->result .= 'The AttributeAuthority is a part of the Identity Provider and follow the same rules for SWAMID Tech 5.1.21 and 5.2.x.<br>';
+      $this->result .= "If the AttributeAuthority part of the entity is not used SWAMID recommends that is removed.\n";
     }
 
     // 5.1.22 / 6.1.20


### PR DESCRIPTION
Hi @btmattsson ,

This is a trivial thing - motivation for me is to hide the message referring to SWAMID rules from the MetadataDisplay page, but I think it also helps putting that into the federation-specific validation class instead of generating the message on the fly in MetadataDisplay.

Please let me know what you think.

Cheers,
Vlad