### PR TITLE
fix: URL validate: follow also code 303

### DIFF
--- a/web/html/src/Common.php
+++ b/web/html/src/Common.php
@@ -253,7 +253,7 @@ class Common {
           curl_setopt($ch, CURLOPT_URL, $target_url);
           $output = curl_exec($ch);
           // check if we received a valid redirect
-          if (curl_errno($ch) === 0 && in_array(curl_getinfo($ch, CURLINFO_HTTP_CODE), array(301,302, 307, 308)) ) {
+          if (curl_errno($ch) === 0 && in_array(curl_getinfo($ch, CURLINFO_HTTP_CODE), array(301, 302, 303, 307, 308)) ) {
             $needs_redirect = true;
             $redirects_found++;
             $target_url = curl_getinfo($ch, CURLINFO_REDIRECT_URL);


### PR DESCRIPTION
Response code 303 (See Other) is essentially a redirect forcing the method to become GET.

Should have been included when switching to explicitly following redirects.

Please let me know if OK to merge @btmattsson 