### PR TITLE
new: validateURLs: set curl overall timeout

### DIFF
--- a/web/html/src/Common.php
+++ b/web/html/src/Common.php
@@ -210,6 +210,7 @@ class Common {
     $default_ports = array( 'http' => 80, 'https' => 443);
 
     curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
 
     curl_setopt($ch, CURLINFO_HEADER_OUT, 0);
 


### PR DESCRIPTION
We already set CURLOPT_CONNECTTIMEOUT, but that overs only establishing the connection.

However, once connected, curl would by default wait indefinitely for a server to respond.

Cap this at 30s to avoid getting stalled by a server that accepts connections but is otherwise unresponsive.