### PR TITLE
fix: showMyEntities: convert userID to lowercase for search

### DIFF
--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -1070,7 +1070,7 @@ function showMyEntities() {
         AND `status` < 4
         AND `userID` = :UserID
       ORDER BY `entityID`, `status`");
-    $entitiesHandler->bindValue(':UserID', $EPPN);
+    $entitiesHandler->bindValue(':UserID', strtolower($EPPN));
   }
   $entityConfirmationHandler = $config->getDb()->prepare(
     "SELECT `lastConfirmed`, `fullName`, `email`, NOW() - INTERVAL 10 MONTH AS `warnDate`,


### PR DESCRIPTION
The functions handling users convert $userID with strtolower()

When searching for entities managed by a user, search by `strtolower($EPPN)` to make the search work also for users with userID not entirely lowercase.

[Spec for samlSubjectID](https://docs.oasis-open.org/security/saml-subject-id-attr/v1.0/cs01/saml-subject-id-attr-v1.0-cs01.html#_Toc536097227) asks for comparison to be done case-insensitive, this will assure that.