### PR TITLE
Misc fixes to entity list rendering

### DIFF
--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -748,6 +748,7 @@ function showEntityList($status = 1) {
 
   printf('
     <table class="table table-striped table-bordered">
+      <thead>
       <tr>
         <th>IdP</th>
         <th>SP</th>
@@ -763,7 +764,10 @@ function showEntityList($status = 1) {
         <th><a href="?%s&%s">OrganizationName%s</a></th>
         <th>%s (UTC)</th>
         <th>%s (UTC)</th>
-        <th><a href="?%s&warnings">warning%s</a> / <a href="?%s&errors">errors%s</a></th></tr>%s',
+        <th><a href="?%s&warnings">warning%s</a> / <a href="?%s&errors">errors%s</a></th>
+      </tr>
+      </thead>
+      <tbody>%s',
     $filter, $feedOrder, $feedArrow, $filter, $entityIDOrder, $entityIDArrow,
     htmlspecialchars($query), $action, $filter,
     $orgOrder, $orgArrow, ($status == 1) ? 'Last Updated' : 'Created' ,
@@ -1035,6 +1039,7 @@ function showList($entities, $minLevel) {
       print "\n      </tr>\n";
     }
   } ?>
+      </tbody>
     </table>
 <?php
 }

--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -653,34 +653,43 @@ function showEntityList($status = 1) {
   $entityIDArrow = '';
   $warningArrow = '';
   $errorArrow = '';
+  $currentSortOrder = '';
   if (isset($_REQUEST['feedDesc'])) {
     $sortOrder = '`publishIn` DESC, `entityID`';
     $feedOrder = 'feedAsc';
     $feedArrow = HTML_CLASS_FA_UP;
+    $currentSortOrder = 'feedDesc';
   } elseif (isset($_REQUEST['feedAsc'])) {
     $sortOrder = '`publishIn` ASC, `entityID`';
     $feedArrow = HTML_CLASS_FA_DOWN;
+    $currentSortOrder = 'feedAsc';
   } elseif (isset($_REQUEST['orgDesc'])) {
     $sortOrder = '`OrganizationName` DESC, `entityID`';
     $orgArrow = HTML_CLASS_FA_UP;
+    $currentSortOrder = 'orgDesc';
   } elseif (isset($_REQUEST['orgAsc'])) {
     $sortOrder = '`OrganizationName` ASC, `entityID`';
     $orgOrder = 'orgDesc';
     $orgArrow = HTML_CLASS_FA_DOWN;
+    $currentSortOrder = 'orgAsc';
   } elseif (isset($_REQUEST['warnings'])) {
     $sortOrder = '`warnings` DESC, `errors` DESC, `errorsNB` DESC, `entityID`, `id`';
     $warningArrow = HTML_CLASS_FA_DOWN;
+    $currentSortOrder = 'warnings';
   } elseif (isset($_REQUEST['errors'])) {
     $sortOrder = '`errors` DESC, `errorsNB` DESC, `warnings` DESC, `entityID`, `id`';
     $errorArrow = HTML_CLASS_FA_DOWN;
+    $currentSortOrder = 'errors';
   } elseif (isset($_REQUEST['entityIDDesc'])) {
     $sortOrder = '`entityID` DESC';
     $entityIDOrder = 'entityIDAsc';
     $entityIDArrow = HTML_CLASS_FA_UP;
+    $currentSortOrder = 'entityIDDesc';
   } else {
     $sortOrder = '`entityID` ASC';
     $entityIDOrder = 'entityIDDesc';
     $entityIDArrow = HTML_CLASS_FA_DOWN;
+    $currentSortOrder = 'entityIDAsc';
   }
 
   if (isset($_REQUEST['query'])) {
@@ -758,6 +767,7 @@ function showEntityList($status = 1) {
             <a href="?%s&%s">entityID%s</a>
             <input type="text" name="query" value="%s">
             <input type="hidden" name="action" value="%s">
+            <input type="hidden" name="%s" value="">
             <input type="submit" value="Filter">
           </form>
         </th>
@@ -769,7 +779,7 @@ function showEntityList($status = 1) {
       </thead>
       <tbody>%s',
     $filter, $feedOrder, $feedArrow, $filter, $entityIDOrder, $entityIDArrow,
-    htmlspecialchars($query), $action,
+    htmlspecialchars($query), $action, $currentSortOrder,
     $filter, $orgOrder, $orgArrow,
     ($status == 1) ? 'Last Updated' : 'Created' ,
     ($status == 1) ? 'Last Confirmed' : 'Last Validated',

--- a/web/html/admin/index.php
+++ b/web/html/admin/index.php
@@ -769,8 +769,9 @@ function showEntityList($status = 1) {
       </thead>
       <tbody>%s',
     $filter, $feedOrder, $feedArrow, $filter, $entityIDOrder, $entityIDArrow,
-    htmlspecialchars($query), $action, $filter,
-    $orgOrder, $orgArrow, ($status == 1) ? 'Last Updated' : 'Created' ,
+    htmlspecialchars($query), $action,
+    $filter, $orgOrder, $orgArrow,
+    ($status == 1) ? 'Last Updated' : 'Created' ,
     ($status == 1) ? 'Last Confirmed' : 'Last Validated',
     $filter, $warningArrow, $filter, $errorArrow, "\n");
   showList($entities, $minLevel);

--- a/web/html/index.php
+++ b/web/html/index.php
@@ -115,23 +115,23 @@ function showEntityList($show) {
       print 'Show what ??????';
       return;
   }
+  printf('    <p>
+    <form>
+      Filter by entityID <input type="text" name="query" value="%s">
+      <input type="hidden" name="show" value="%s">
+      <input type="submit" value="Filter">
+    </form>%s', htmlspecialchars($query), htmlspecialchars($show), "\n");
   printf ('    <div class="table-responsive"><table id="entities-table" class="table table-striped table-bordered">
       <thead>
         <tr>
-          <th>
-            <form>
-              entityID <input type="text" name="query" value="%s">
-              <input type="hidden" name="show" value="%s">
-              <input type="submit" value="Filter">
-            </form>
-          </th>
+          <th>entityID</th>
           <th>Published in</th>
           <th>DisplayName</th>
           <th>OrganizationName</th>
           %s
         </tr>
       </thead>%s'
-    , htmlspecialchars($query), htmlspecialchars($show), $extraTH, "\n");
+    , $extraTH, "\n");
   $html->addTableSort('entities-table');
   $entities->bindValue(':Query', "%".$query."%");
   showList($entities, $show);


### PR DESCRIPTION
In admin/index.html showEntityList:
* preserve sort order when searching
* wrap table rows in explicit thead / tbody (comestic / purist fix only)

In index.html showEntityList, move form for filtering by entityID out of the table to avoid clashes with DataTables, solving issues where DataTables grabs user input (click and/or Enter)  meant for the form.